### PR TITLE
Epitech Emacs Herders for C++

### DIFF
--- a/src/.emacs.d/lisp/std_comment.el
+++ b/src/.emacs.d/lisp/std_comment.el
@@ -12,8 +12,7 @@
 
 (setq std-c-alist               '( (cs . "/*") (cc . "** ") (ce . "*/") )
       std-css-alist             '( (cs . "/*") (cc . "** ") (ce . "*/") )
-      std-c++-alist             '( (cs . "/*") (cc . "** ") (ce . "*/") )
-      std-cpp-alist             '( (cs . "//") (cc . "// ") (ce . "//") )
+      std-cpp-alist             '( (cs . "/*") (cc . "** ") (ce . "*/") )
       std-pov-alist             '( (cs . "//") (cc . "// ") (ce . "//") )
       std-java-alist            '( (cs . "//") (cc . "// ") (ce . "//") )
       std-latex-alist           '( (cs . "%%") (cc . "%% ") (ce . "%%") )
@@ -35,7 +34,6 @@
 (setq std-modes-alist '(("C"                    . std-c-alist)
 			("C/l"                  . std-c-alist)
                         ("CSS"                  . std-c-alist)
-			("C++"                  . std-c++-alist)
                         ("PoV"                  . std-pov-alist)
                         ("C++"                  . std-cpp-alist)
                         ("C++/l"                . std-cpp-alist)

--- a/src/.emacs.d/lisp/std_comment.el
+++ b/src/.emacs.d/lisp/std_comment.el
@@ -12,6 +12,7 @@
 
 (setq std-c-alist               '( (cs . "/*") (cc . "** ") (ce . "*/") )
       std-css-alist             '( (cs . "/*") (cc . "** ") (ce . "*/") )
+      std-c++-alist             '( (cs . "/*") (cc . "** ") (ce . "*/") )
       std-cpp-alist             '( (cs . "//") (cc . "// ") (ce . "//") )
       std-pov-alist             '( (cs . "//") (cc . "// ") (ce . "//") )
       std-java-alist            '( (cs . "//") (cc . "// ") (ce . "//") )
@@ -34,6 +35,7 @@
 (setq std-modes-alist '(("C"                    . std-c-alist)
 			("C/l"                  . std-c-alist)
                         ("CSS"                  . std-c-alist)
+			("C++"                  . std-c++-alist)
                         ("PoV"                  . std-pov-alist)
                         ("C++"                  . std-cpp-alist)
                         ("C++/l"                . std-cpp-alist)


### PR DESCRIPTION
Official headers for C++ are the same as the C ones (as seen in the C++ Coding Style pdf) :
```
/*
** EPITECH PROJECT, $YEAR
** $PROJECT_NAME
** File description:
** $FILE_DESCRIPTION
*/
```
But those given by this script are the following :

```
//
// EPITECH PROJECT, $YEAR
// $PROJECT_NAME
// File description:
// $FILE_DESCRIPTION
//
```

Those are change which fix the C++ headers according to Epitech Coding Style PDF